### PR TITLE
Remove unnecessary getty and udev targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,10 @@ RUN chmod +x initctl_faker && rm -fr /sbin/initctl && ln -s /initctl_faker /sbin
 RUN mkdir -p /etc/ansible
 RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
 
+# Remove unnecessary getty and udev targets that result in high CPU usage when using
+# multiple containers with Molecule (https://github.com/ansible/molecule/issues/1104)
+RUN rm -f /lib/systemd/system/systemd*udev* \
+  && rm -f /lib/systemd/system/getty.target
+
 VOLUME ["/sys/fs/cgroup", "/tmp", "/run"]
 CMD ["/lib/systemd/systemd"]


### PR DESCRIPTION
Solves issue #9. Thought I would issue a pull request to see if this is something you'd consider merging before maintaining my own images based on yours.

Thanks for maintaining these high quality images for everyone.