### PR TITLE
Add `ansible` user to enable testing of roles with non-`root` user

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,18 @@ before_install:
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 
+env:
+  ANSIBLE_USER: ansible
+
 script:
   # Test building Dockerfile.
   - docker build -t docker-ansible .
 
   # Test running the container.
   - docker run --name test-container -d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro docker-ansible
+
+  # Verify that `ansible` user exists and is a sudoer
+  - docker exec --tty test-container env TERM=xterm sudo -u ${ANSIBLE_USER} sudo -v
 
   # Verify Ansible is available in the container.
   - docker exec --tty test-container env TERM=xterm ansible --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,13 @@ RUN chmod +x initctl_faker && rm -fr /sbin/initctl && ln -s /initctl_faker /sbin
 RUN mkdir -p /etc/ansible
 RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
 
+# Create `ansible` user with sudo permissions
+ENV ANSIBLE_USER=ansible SUDO_GROUP=sudo
+RUN set -xe \
+  && groupadd -r ${ANSIBLE_USER} \
+  && useradd -m -g ${ANSIBLE_USER} ${ANSIBLE_USER} \
+  && usermod -aG ${SUDO_GROUP} ${ANSIBLE_USER} \
+  && sed -i "/^%${SUDO_GROUP}/s/ALL\$/NOPASSWD:ALL/g" /etc/sudoers
+
 VOLUME ["/sys/fs/cgroup", "/tmp", "/run"]
 CMD ["/lib/systemd/systemd"]


### PR DESCRIPTION
Another change that I wanted to check if you'd consider merging.

Adds a non-root sudoer called `ansible` and ensures that `sudo` does not require a password to match how these images are set up in cloud providers like AWS/Azure/GCP.

Can be used with molecule/Docker like this:

```yaml
# molecule/default/playbook.yml
---
- name: Converge
  hosts: all
  vars:
    ansible_user: ansible
  roles:
    - role: ...
```