### PR TITLE
Cleanup Systemd files and add Travis-CI test for Systemd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,6 @@ script:
 
   # Verify Ansible is available in the container.
   - docker exec --tty test-container env TERM=xterm ansible --version
+
+  # Verify that Systemd is working
+  - docker exec --tty test-container env TERM=xterm sh -c 'systemctl status --no-pager'

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,16 @@ RUN apt-get update \
     && apt-get clean
 RUN sed -i 's/^\($ModLoad imklog\)/#\1/' /etc/rsyslog.conf
 
+# Cleanup unwanted systemd files -- See https://hub.docker.com/_/centos/
+RUN find /lib/systemd/system/sysinit.target.wants/* ! -name systemd-tmpfiles-setup.service -delete; \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+
 # Install Ansible via Pip.
 RUN pip install $pip_packages
 


### PR DESCRIPTION
**Observation:**
I was testing with Molecule on an *Ubuntu 18.04 host* and each time I created privileged containers using your Debian based images that support Systemd, it logged me out (Red Hat based images worked without a problem). Creating the containers manually caused the same problem (as expected). 

**Root Cause:**
Extraneous Systemd files + privileged mode = [troubling times in the kingdom](https://www.youtube.com/watch?v=RHAP3DTESS4).

**Recommendation:**
- Following the info here [https://hub.docker.com/_/centos/]( https://github.com/docker-library/docs/blob/master/centos/README.md#dockerfile-for-systemd-base-image ), we should clean up those unwanted Systemd files on Debian based systems as well. The main difference with my change is that I used [`find`]( https://github.com/jamrok/docker-ubuntu1804-ansible/blob/fix-systemd/Dockerfile#L20 ) to do the same cleanup as listed [here](https://github.com/docker-library/docs/blame/master/centos/README.md#L101-L102).
- The change in this PR allows Systemd to run properly inside Ubuntu and Debian based containers without affecting the host (helps for local testing).
- This change should be applied to your Ubuntu 16.04, Debian 8 and Debian 9 repositories as well.

**Testing:**
The following shows the Systemd status when the files are present (your image before the change):
https://travis-ci.com/jamrok/docker-ubuntu1804-ansible/builds/101129316#L1102-L1135

The following shows the Systemd status when the files are removed (after the change):
https://travis-ci.com/jamrok/docker-ubuntu1804-ansible/jobs/178182250#L1106-L1120

---
I was checking your Issues and it seems this might solve for #9 as well.

Let me know what you think,

Thanks