### PR TITLE
Ensure /var/lib/apt/lists/partial is removed from final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,9 @@ RUN apt-get update \
        python3-yaml \
        software-properties-common \
        rsyslog systemd systemd-cron sudo iproute2 \
+    && apt-get clean \
     && rm -Rf /var/lib/apt/lists/* \
-    && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
-    && apt-get clean
+    && rm -Rf /usr/share/doc && rm -Rf /usr/share/man
 RUN sed -i 's/^\($ModLoad imklog\)/#\1/' /etc/rsyslog.conf
 
 # Upgrade pip to latest version.


### PR DESCRIPTION
The file is being correctly removed but is then re-added with a new timestamp by the `apt-get clean` command.

When this file is left inside the final image it confuses the `cache_valid_time` option of the apt module in ansible - this module will think that a recent cache is present but actually there is no cache present because we have removed it.

This causes intermittent moecule test failures for one of my roles, depending on how long after the container was built the tests run (the role uses `cache_valid_time`).